### PR TITLE
Slew of deprecations & fixes

### DIFF
--- a/src/fix.rs
+++ b/src/fix.rs
@@ -40,6 +40,7 @@ pub struct Fix<'a, F: 'a, T: 'a, R: 'a = T>(&'a F, PhantomData<fn(T) -> R>);
 impl<'a, F, T, R> Fix<'a, F, T, R>
     where F: Fn(Fix<F, T, R>, T) -> R,
 {
+    /// Create a new fix from the reference to closure `f`
     pub fn new(f: &'a F) -> Self {
         Fix(f, PhantomData)
     }
@@ -87,6 +88,7 @@ pub fn fix<T, R, F>(init: T, closure: F) -> R
 impl<'a, F, T, R> Fix<'a, F, T, R>
     where F: Fn(Fix<F, T, R>, T) -> R,
 {
+    /// Call the fix using the argument `arg`
     pub fn call(&self, arg: T) -> R {
         let f = *self;
         f.0(f, arg)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,12 +59,14 @@ pub mod prelude {
 }
 
 /// Compare if **a** and **b** are equal *as pointers*.
+#[deprecated(note="use std::ptr::eq")]
 #[inline]
 pub fn ref_eq<T>(a: &T, b: &T) -> bool {
-    ptr_eq(a, b)
+    std::ptr::eq(a, b)
 }
 
 /// Compare if **a** and **b** are equal pointers.
+#[deprecated(note="use std::ptr::eq")]
 #[inline]
 pub fn ptr_eq<T>(a: *const T, b: *const T) -> bool {
     a == b

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,10 @@ pub mod prelude {
 
 /// Compare if **a** and **b** are equal *as pointers*.
 #[deprecated(note="use std::ptr::eq")]
+#[allow(deprecated)]
 #[inline]
 pub fn ref_eq<T>(a: &T, b: &T) -> bool {
-    std::ptr::eq(a, b)
+    ptr_eq(a, b)
 }
 
 /// Compare if **a** and **b** are equal pointers.

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -385,9 +385,9 @@ impl_pod!{@array 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 /// fn count_ones(data: &[u8]) -> u32 {
 ///     let mut total = 0;
 ///     let (head, mid, tail) = split_aligned_for::<[u64; 2]>(data);
-///     total += head.iter().map(|x| x.count_ones()).sum();
-///     total += mid.iter().map(|x| x[0].count_ones() + x[1].count_ones()).sum();
-///     total += tail.iter().map(|x| x.count_ones()).sum();
+///     total += head.iter().map(|x| x.count_ones()).sum::<u32>();
+///     total += mid.iter().map(|x| x[0].count_ones() + x[1].count_ones()).sum::<u32>();
+///     total += tail.iter().map(|x| x.count_ones()).sum::<u32>();
 ///     total
 /// }
 ///

--- a/src/string.rs
+++ b/src/string.rs
@@ -52,9 +52,11 @@ pub trait StrExt {
 }
 
 /// Extension trait for `str` for string slicing without panicking
+#[deprecated(note="Use str::get with a range instead")]
 pub trait StrSlice {
     /// Return a slice of the string, if it is in bounds /and on character boundaries/,
     /// otherwise return `None`
+    #[deprecated(note="Use str::get with a range instead")]
     fn get_slice<R>(&self, r: R) -> Option<&str> where R: IndexRange;
 }
 
@@ -95,6 +97,7 @@ impl StrExt for str {
     }
 }
 
+#[allow(deprecated)]
 impl StrSlice for str {
     fn get_slice<R>(&self, r: R) -> Option<&str> where R: IndexRange {
         let start = r.start().unwrap_or(0);
@@ -334,6 +337,7 @@ fn str_windows_not_0() {
     CharWindows::new("abc", 0);
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_acc_index() {
     let s = "Abcαβγ";
@@ -365,6 +369,7 @@ fn test_string_ext() {
     assert_eq!(s, "αxβγabc");
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_slice() {
     let t = "αβγabc";

--- a/src/string.rs
+++ b/src/string.rs
@@ -47,6 +47,7 @@ pub trait StrExt {
     ///     assert!("Abcαβγ".is_acceptable_index(ix));
     /// }
     /// ```
+    #[deprecated(note="Use str::is_char_boundary instead")]
     fn is_acceptable_index(&self, index: usize) -> bool;
 }
 
@@ -98,7 +99,7 @@ impl StrSlice for str {
     fn get_slice<R>(&self, r: R) -> Option<&str> where R: IndexRange {
         let start = r.start().unwrap_or(0);
         let end = r.end().unwrap_or(self.len());
-        if start <= end && self.is_acceptable_index(start) && self.is_acceptable_index(end) {
+        if start <= end && self.is_char_boundary(start) && self.is_char_boundary(end) {
             Some(&self[start..end])
         } else {
             None
@@ -163,7 +164,7 @@ pub trait StringExt {
 impl StringExt for String {
     /// **Panics** if `index` is out of bounds.
     fn insert_str(&mut self, index: usize, s: &str) {
-        assert!(self.is_acceptable_index(index));
+        assert!(self.is_char_boundary(index));
         self.reserve(s.len());
         // move the tail, then copy in the string
         unsafe {

--- a/src/string.rs
+++ b/src/string.rs
@@ -14,6 +14,7 @@ pub trait StrExt {
     /// Repeat the string `n` times.
     ///
     /// Requires `feature="std"`
+    #[deprecated(note="Use str::repeat instead")]
     fn rep(&self, n: usize) -> String;
 
     #[cfg(feature="std")]

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -22,18 +22,6 @@ pub fn vec<I>(iterable: I) -> Vec<I::Item>
 ///
 /// Requires `feature="std"`
 pub trait VecExt<T> {
-    /// Remove elements in a range, and insert from an iterator in their place.
-    ///
-    /// The removed and inserted ranges don't have to match in length.
-    ///
-    /// **Panics** if range `r` is out of bounds.
-    ///
-    /// **Panics** if iterator `iter` is not of exact length.
-    fn splice<R, I>(&mut self, r: R, iter: I)
-        where I: IntoIterator<Item=T>,
-              I::IntoIter: ExactSizeIterator,
-              R: IndexRange;
-
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all elements `e` such that `f(&mut e)` returns false.
@@ -65,62 +53,6 @@ pub trait VecExt<T> {
 ///
 /// **Panics** if iterator `iter` is not of exact length.
 impl<T> VecExt<T> for Vec<T> {
-    fn splice<R, I>(&mut self, r: R, iter: I)
-        where I: IntoIterator<Item=T>,
-              I::IntoIter: ExactSizeIterator,
-              R: IndexRange,
-    {
-        let v = self;
-        let mut iter = iter.into_iter();
-        let (input_len, _) = iter.size_hint();
-        let old_len = v.len();
-        let r = r.start().unwrap_or(0)..r.end().unwrap_or(old_len);
-        assert!(r.start <= r.end);
-        assert!(r.end <= v.len());
-        let rm_len = r.end - r.start;
-        v.reserve(input_len.saturating_sub(rm_len));
-
-        unsafe {
-            let ptr = v.as_mut_ptr();
-            v.set_len(r.start);
-
-            // drop all elements in `r`
-            {
-                let mslc = slice::from_raw_parts_mut(ptr.offset(r.start as isize), rm_len);
-                for elt_ptr in mslc {
-                    ptr::read(elt_ptr); // Possible panic
-                }
-            }
-
-            if rm_len != input_len {
-                // move tail elements
-                ptr::copy(ptr.offset(r.end as isize),
-                          ptr.offset((r.start + input_len) as isize),
-                          old_len - r.end);
-            }
-
-            // fill in elements from the iterator
-            // FIXME: On panic, drop tail properly too (using panic guard)
-            {
-                let grow_slc = slice::from_raw_parts_mut(ptr.offset(r.start as isize), input_len);
-                let mut len = r.start;
-                for slot_ptr in grow_slc {
-                    if let Some(input_elt) = iter.next() { // Possible Panic
-                        ptr::write(slot_ptr, input_elt);
-                    } else {
-                        // FIXME: Skip check with trusted iterators
-                        panic!("splice: iterator too short");
-                    }
-                    // update length to drop as much as possible on panic
-                    len += 1;
-                    v.set_len(len);
-                }
-                v.set_len(old_len - rm_len + input_len);
-            }
-        }
-        //assert!(iter.next().is_none(), "splice: iterator not exact size");
-    }
-
     // Adapted from libcollections/vec.rs in Rust
     // Primary author in Rust: Michael Darakananda
     fn retain_mut<F>(&mut self, mut f: F)
@@ -144,6 +76,73 @@ impl<T> VecExt<T> for Vec<T> {
         }
     }
 }
+
+/// Remove elements in a range, and insert from an iterator in their place.
+///
+/// The removed and inserted ranges don't have to match in length.
+///
+/// **Panics** if range `r` is out of bounds.
+///
+/// **Panics** if iterator `iter` is not of exact length.
+///
+/// *See also Vec's splice method, which is more flexible. As of this writing
+/// it is an experimental feature.*
+fn splice<T, R, I>(v: &mut Vec<T>, r: R, iter: I)
+    where I: IntoIterator<Item=T>,
+          I::IntoIter: ExactSizeIterator,
+          R: IndexRange
+{
+    let mut iter = iter.into_iter();
+    let (input_len, _) = iter.size_hint();
+    let old_len = v.len();
+    let r = r.start().unwrap_or(0)..r.end().unwrap_or(old_len);
+    assert!(r.start <= r.end);
+    assert!(r.end <= v.len());
+    let rm_len = r.end - r.start;
+    v.reserve(input_len.saturating_sub(rm_len));
+
+    unsafe {
+        let ptr = v.as_mut_ptr();
+        v.set_len(r.start);
+
+        // drop all elements in `r`
+        {
+            let mslc = slice::from_raw_parts_mut(ptr.offset(r.start as isize), rm_len);
+            for elt_ptr in mslc {
+                ptr::read(elt_ptr); // Possible panic
+            }
+        }
+
+        if rm_len != input_len {
+            // move tail elements
+            ptr::copy(ptr.offset(r.end as isize),
+                      ptr.offset((r.start + input_len) as isize),
+                      old_len - r.end);
+        }
+
+        // fill in elements from the iterator
+        // FIXME: On panic, drop tail properly too (using panic guard)
+        {
+            let grow_slc = slice::from_raw_parts_mut(ptr.offset(r.start as isize), input_len);
+            let mut len = r.start;
+            for slot_ptr in grow_slc {
+                if let Some(input_elt) = iter.next() { // Possible Panic
+                    ptr::write(slot_ptr, input_elt);
+                } else {
+                    // FIXME: Skip check with trusted iterators
+                    panic!("splice: iterator too short");
+                }
+                // update length to drop as much as possible on panic
+                len += 1;
+                v.set_len(len);
+            }
+            v.set_len(old_len - rm_len + input_len);
+        }
+    }
+    //assert!(iter.next().is_none(), "splice: iterator not exact size");
+    }
+
+
 
 pub trait VecFindRemove {
     type Item;
@@ -181,27 +180,27 @@ fn test_splice() {
     use std::iter::once;
 
     let mut v = vec![1, 2, 3, 4];
-    VecExt::splice(&mut v, 1..1, vec![9, 9]);
+    splice(&mut v, 1..1, vec![9, 9]);
     assert_eq!(v, &[1, 9, 9, 2, 3, 4]);
 
     let mut v = vec![1, 2, 3, 4];
-    VecExt::splice(&mut v, 1..2, vec![9, 9]);
+    splice(&mut v, 1..2, vec![9, 9]);
     assert_eq!(v, &[1, 9, 9, 3, 4]);
 
     let mut v = vec![1, 2, 3, 4, 5];
-    VecExt::splice(&mut v, 1..4, vec![9, 9]);
+    splice(&mut v, 1..4, vec![9, 9]);
     assert_eq!(v, &[1, 9, 9, 5]);
 
     let mut v = vec![1, 2, 3, 4];
-    VecExt::splice(&mut v, 0..4, once(9));
+    splice(&mut v, 0..4, once(9));
     assert_eq!(v, &[9]);
 
     let mut v = vec![1, 2, 3, 4];
-    VecExt::splice(&mut v, 0..4, None);
+    splice(&mut v, 0..4, None);
     assert_eq!(v, &[]);
 
     let mut v = vec![1, 2, 3, 4];
-    VecExt::splice(&mut v, 1.., Some(9));
+    splice(&mut v, 1.., Some(9));
     assert_eq!(v, &[1, 9]);
 }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -3,10 +3,6 @@
 //! Requires `feature="std"`
 #![cfg(feature="std")]
 
-use range::IndexRange;
-use std::ptr;
-use std::slice;
-
 use slice::SliceFind;
 
 
@@ -44,14 +40,6 @@ pub trait VecExt<T> {
         where F: FnMut(&mut T) -> bool;
 }
 
-/// `Vec::splice`: Remove elements in a range, and insert from an iterator
-/// in their place.
-///
-/// The removed and inserted ranges don't have to match in length.
-///
-/// **Panics** if range `r` is out of bounds.
-///
-/// **Panics** if iterator `iter` is not of exact length.
 impl<T> VecExt<T> for Vec<T> {
     // Adapted from libcollections/vec.rs in Rust
     // Primary author in Rust: Michael Darakananda
@@ -77,70 +65,6 @@ impl<T> VecExt<T> for Vec<T> {
     }
 }
 
-/// Remove elements in a range, and insert from an iterator in their place.
-///
-/// The removed and inserted ranges don't have to match in length.
-///
-/// **Panics** if range `r` is out of bounds.
-///
-/// **Panics** if iterator `iter` is not of exact length.
-///
-/// *See also Vec's splice method, which is more flexible. As of this writing
-/// it is an experimental feature.*
-fn splice<T, R, I>(v: &mut Vec<T>, r: R, iter: I)
-    where I: IntoIterator<Item=T>,
-          I::IntoIter: ExactSizeIterator,
-          R: IndexRange
-{
-    let mut iter = iter.into_iter();
-    let (input_len, _) = iter.size_hint();
-    let old_len = v.len();
-    let r = r.start().unwrap_or(0)..r.end().unwrap_or(old_len);
-    assert!(r.start <= r.end);
-    assert!(r.end <= v.len());
-    let rm_len = r.end - r.start;
-    v.reserve(input_len.saturating_sub(rm_len));
-
-    unsafe {
-        let ptr = v.as_mut_ptr();
-        v.set_len(r.start);
-
-        // drop all elements in `r`
-        {
-            let mslc = slice::from_raw_parts_mut(ptr.offset(r.start as isize), rm_len);
-            for elt_ptr in mslc {
-                ptr::read(elt_ptr); // Possible panic
-            }
-        }
-
-        if rm_len != input_len {
-            // move tail elements
-            ptr::copy(ptr.offset(r.end as isize),
-                      ptr.offset((r.start + input_len) as isize),
-                      old_len - r.end);
-        }
-
-        // fill in elements from the iterator
-        // FIXME: On panic, drop tail properly too (using panic guard)
-        {
-            let grow_slc = slice::from_raw_parts_mut(ptr.offset(r.start as isize), input_len);
-            let mut len = r.start;
-            for slot_ptr in grow_slc {
-                if let Some(input_elt) = iter.next() { // Possible Panic
-                    ptr::write(slot_ptr, input_elt);
-                } else {
-                    // FIXME: Skip check with trusted iterators
-                    panic!("splice: iterator too short");
-                }
-                // update length to drop as much as possible on panic
-                len += 1;
-                v.set_len(len);
-            }
-            v.set_len(old_len - rm_len + input_len);
-        }
-    }
-    //assert!(iter.next().is_none(), "splice: iterator not exact size");
-    }
 
 
 
@@ -173,35 +97,6 @@ impl<T> VecFindRemove for Vec<T> {
     {
         self.rfind(elt).map(|i| (i, self.remove(i)))
     }
-}
-
-#[test]
-fn test_splice() {
-    use std::iter::once;
-
-    let mut v = vec![1, 2, 3, 4];
-    splice(&mut v, 1..1, vec![9, 9]);
-    assert_eq!(v, &[1, 9, 9, 2, 3, 4]);
-
-    let mut v = vec![1, 2, 3, 4];
-    splice(&mut v, 1..2, vec![9, 9]);
-    assert_eq!(v, &[1, 9, 9, 3, 4]);
-
-    let mut v = vec![1, 2, 3, 4, 5];
-    splice(&mut v, 1..4, vec![9, 9]);
-    assert_eq!(v, &[1, 9, 9, 5]);
-
-    let mut v = vec![1, 2, 3, 4];
-    splice(&mut v, 0..4, once(9));
-    assert_eq!(v, &[9]);
-
-    let mut v = vec![1, 2, 3, 4];
-    splice(&mut v, 0..4, None);
-    assert_eq!(v, &[]);
-
-    let mut v = vec![1, 2, 3, 4];
-    splice(&mut v, 1.., Some(9));
-    assert_eq!(v, &[1, 9]);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,6 +4,7 @@ extern crate itertools;
 
 use odds::string::StrExt;
 
+#[allow(deprecated)]
 #[test]
 fn rep() {
     assert_eq!("".rep(0), "");


### PR DESCRIPTION
- Deprecate functionality that has stable equivalents in libstd now
- Vec::splice is removed directly, since it conflicts otherwise.