### PR TITLE
Revert the fix function back to its odds 0.2.x shape

### DIFF
--- a/src/fix.rs
+++ b/src/fix.rs
@@ -1,13 +1,13 @@
 
 /// Fixpoint combinator for rust closures, generalized over the return type.
 ///
+/// **Note:** Use this best through the [`fix`](fn.fix.html) function.
+///
 /// In **Fix\<T, R\>**, **T** is the argument type, and **R** is the return type,
 /// **R** defaults to **T**.
 ///
 /// Calling the `Fix` value only supports function call notation with the nightly
 /// channel and the crate feature ‘unstable’ enabled; use the .call() method otherwise.
-///
-/// Use this best through the `fix` function.
 ///
 /// ```
 /// use odds::Fix;

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -1,8 +1,7 @@
-use std::marker::PhantomData;
 
 /// Fixpoint combinator for rust closures, generalized over the return type.
 ///
-/// In **Fix\<F, T, R\>**, **T** is the argument type, and **R** is the return type,
+/// In **Fix\<T, R\>**, **T** is the argument type, and **R** is the return type,
 /// **R** defaults to **T**.
 ///
 /// Calling the `Fix` value only supports function call notation with the nightly
@@ -14,8 +13,8 @@ use std::marker::PhantomData;
 /// use odds::Fix;
 /// use odds::fix;
 ///
-/// let c = |f: Fix<_, i32>, x| if x == 0 { 1 } else { x * f.call(x - 1) };
-/// let fact = Fix::new(&c);
+/// let c = |f: Fix<i32>, x| if x == 0 { 1 } else { x * f.call(x - 1) };
+/// let fact = Fix(&c);
 /// assert_eq!(fact.call(5), 120);
 ///
 /// let data = [true, false];
@@ -29,22 +28,13 @@ use std::marker::PhantomData;
 // using feature `unstable`
 use odds::Fix;
 
-let c = |f: Fix<_, i32>, x| if x == 0 { 1 } else { x * f(x - 1) };
-let fact = Fix::new(&c);
+let c = |f: Fix<i32>, x| if x == 0 { 1 } else { x * f(x - 1) };
+let fact = Fix(&c);
 assert_eq!(fact(5), 120);
 ```
 "
 )]
-pub struct Fix<'a, F: 'a, T: 'a, R: 'a = T>(&'a F, PhantomData<fn(T) -> R>);
-
-impl<'a, F, T, R> Fix<'a, F, T, R>
-    where F: Fn(Fix<F, T, R>, T) -> R,
-{
-    /// Create a new fix from the reference to closure `f`
-    pub fn new(f: &'a F) -> Self {
-        Fix(f, PhantomData)
-    }
-}
+pub struct Fix<'a, T: 'a, R: 'a = T>(pub &'a Fn(Fix<T, R>, T) -> R);
 
 /// Fixpoint combinator for rust closures, generalized over the return type.
 ///
@@ -80,14 +70,12 @@ assert_eq!(120, fix(5, |f, x| if x == 0 { 1 } else { x * f(x - 1) }));
 "
 )]
 pub fn fix<T, R, F>(init: T, closure: F) -> R
-    where F: Fn(Fix<F, T, R>, T) -> R
+    where F: Fn(Fix<T, R>, T) -> R
 {
-    Fix(&closure, PhantomData).call(init)
+    Fix(&closure).call(init)
 }
 
-impl<'a, F, T, R> Fix<'a, F, T, R>
-    where F: Fn(Fix<F, T, R>, T) -> R,
-{
+impl<'a, T, R> Fix<'a, T, R> {
     /// Call the fix using the argument `arg`
     pub fn call(&self, arg: T) -> R {
         let f = *self;
@@ -95,16 +83,14 @@ impl<'a, F, T, R> Fix<'a, F, T, R>
     }
 }
 
-impl<'a, F, T, R> Clone for Fix<'a, F, T, R> {
+impl<'a, T, R> Clone for Fix<'a, T, R> {
     fn clone(&self) -> Self { *self }
 }
 
-impl<'a, F, T, R> Copy for Fix<'a, F, T, R> { }
+impl<'a, T, R> Copy for Fix<'a, T, R> { }
 
 #[cfg(feature="unstable")]
-impl<'a, F, T, R> FnOnce<(T,)> for Fix<'a, F, T, R>
-    where F: Fn(Fix<F, T, R>, T) -> R,
-{
+impl<'a, T, R> FnOnce<(T,)> for Fix<'a, T, R> {
     type Output = R;
     #[inline]
     extern "rust-call" fn call_once(self, x: (T,)) -> R {
@@ -113,9 +99,7 @@ impl<'a, F, T, R> FnOnce<(T,)> for Fix<'a, F, T, R>
 }
 
 #[cfg(feature="unstable")]
-impl<'a, F, T, R> FnMut<(T,)> for Fix<'a, F, T, R>
-    where F: Fn(Fix<F, T, R>, T) -> R,
-{
+impl<'a, T, R> FnMut<(T,)> for Fix<'a, T, R> {
     #[inline]
     extern "rust-call" fn call_mut(&mut self, x: (T,)) -> R {
         self.call(x.0)
@@ -123,11 +107,10 @@ impl<'a, F, T, R> FnMut<(T,)> for Fix<'a, F, T, R>
 }
 
 #[cfg(feature="unstable")]
-impl<'a, F, T, R> Fn<(T,)> for Fix<'a, F, T, R>
-    where F: Fn(Fix<F, T, R>, T) -> R,
-{
+impl<'a, T, R> Fn<(T,)> for Fix<'a, T, R> {
     #[inline]
     extern "rust-call" fn call(&self, x: (T,)) -> R {
         self.call(x.0)
     }
 }
+


### PR DESCRIPTION
Self-referential static type closures are not supported by Rust, decided clearly rust-lang/rust/issues/46062

- This is a technically breaking change in Rust to preserve the soundness of the type system (something like that) and we take the opportunity to mildly break `fix` to fix it, going back to the previous form.
- I don't expect any impact at all, because 0.3. is new and nobody is using this cool recursivity combinator anyway.